### PR TITLE
Use the same format for the default options as for the overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Instead of running complicated regexps on the html string itself, why not lettin
 ```
 
 ### Options
-`options.allowedNodes` - An array of nodes to  keep (eg: ['div', 'br', 'strong'])  
-`options.allowedAttrs` - An array of attributes to  keep (eg: ['alt', 'href', 'src'])  
+`options.allowedNodes` - An array of nodes to  keep (eg: ['div', 'br', 'strong'])
+`options.allowedAttrs` - An array of attributes to  keep (eg: ['alt', 'href', 'src'])
 
 ### Defaults
-`options.allowedNodes` - 'div,p,a,br,i,em,strong,b,img'  
-`options.allowedAttrs` - 'href,title,alt,src,width,height'  
+`options.allowedNodes` - ['div, 'p', 'a', 'br', 'i', 'em', 'strong', 'b', 'img']
+`options.allowedAttrs` - ['href', 'title', 'alt', 'src', 'width', 'height']

--- a/src/filthy.js
+++ b/src/filthy.js
@@ -1,5 +1,5 @@
-const ALLOWED_TAGS = 'div,p,a,br,i,em,strong,b,img';
-const ALLOWED_ATTRS = 'href,title,alt,src,width,height';
+const ALLOWED_TAGS = ['div', 'p', 'a', 'br', 'i', 'em', 'strong', 'b', 'img'];
+const ALLOWED_ATTRS = ['href', 'title', 'alt', 'src', 'width', 'height'];
 
 const createDoc = () => document.implementation.createHTMLDocument();
 const createDiv = doc => doc.createElement('div');
@@ -29,8 +29,8 @@ function cleanNode(originalNode, allowedAttrs) {
 
 function filter(node, opts = {}) {
   const nodeName = node.nodeName.toLowerCase();
-  const allowedNodes = opts.allowedNodes || ALLOWED_TAGS.split(',');
-  const allowedAttrs = opts.allowedAttrs || ALLOWED_ATTRS.split(',');
+  const allowedNodes = opts.allowedNodes || ALLOWED_TAGS;
+  const allowedAttrs = opts.allowedAttrs || ALLOWED_ATTRS;
 
   if (nodeName === '#text') return node;
   if (nodeName === '#comment') return doc.createTextNode('');


### PR DESCRIPTION
The options accepted an array of elements and attributes, while the
defaults contained a string of comma separated words. Aligning the two
makes it a bit more readable and consistent.